### PR TITLE
buffer pool backing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 arc-swap = "1.7.1"
 bincode = "=1.3.3"
 flexi_logger = { version = "=0.29.0", features = ["async"] }
-futures-util = { version = "=0.3.30", features = ["sink"] }
+futures-util = { version = "=0.3.31", features = ["sink"] }
 hex = "=0.4.3"
 log = "=0.4.22"
 md-5 = "=0.10.6"

--- a/src/broker/forwarding_table.rs
+++ b/src/broker/forwarding_table.rs
@@ -53,7 +53,7 @@ impl ForwardingTable {
             // get the next message from the client and break it down into
             // the topic and the body
             let rx_count = if let Some(rx) = p.rx_mapping.load().as_ref() {
-                rx.dequeue_bulk_bytes(&mut buf)
+                unsafe { &mut *rx.get().get() }.dequeue_bulk_bytes(&mut buf)
             } else {
                 0
             };
@@ -69,7 +69,7 @@ impl ForwardingTable {
                     continue;
                 };
 
-                tx.enqueue_bulk_bytes(&mut buf[..rx_count]);
+                unsafe { &mut *tx.get().get() }.enqueue_bulk_bytes(&mut buf[..rx_count]);
             }
         }
     }

--- a/src/queue/buffer_pool.rs
+++ b/src/queue/buffer_pool.rs
@@ -1,26 +1,33 @@
 use std::mem::size_of;
+use std::sync::atomic::{
+    AtomicBool, 
+    AtomicU16, 
+    AtomicU32,
+    Ordering,
+};
+
 
 /// Metadata at the start of every buffer
 #[repr(C)]
 struct BufferHeader {
-    /// If [`more`]` is true, the index of the next buffer as part of a multipart
-    /// message
-    /// 
-    /// [`more`]: Self::more
-    next: u32,
+    /// If there are more buffers in the message. If true, [`next`] refers to
+    /// the next message
+    ///
+    /// [`next`]: Self::next
+    next: AtomicU32,
 
     /// Length of the data in the current buffer (NOT the total length!)
-    length: u16,
+    length: AtomicU16,
 
     /// Whether or not this buffer is available for use. If true, all other
     /// fields are in an undefined state
-    free: bool,
+    free: AtomicBool,
 
-    /// If there are more buffers in the message. If true, [`next`] refers to
-    /// the nest message
-    /// 
-    /// [`next`]: Self::next
-    more: bool,
+    /// If [`more`]` is true, the index of the next buffer is part of a multipart
+    /// message
+    ///
+    /// [`more`]: Self::more
+    more: AtomicBool,
 }
 
 /// Cheap wrapper around a memory region pointing to some shared memory.
@@ -38,28 +45,36 @@ pub struct BufferPool {
 
     /// List of buffers in the pool
     pool: Vec<Buffer>,
+
+    /// Size of an individual buffer
+    buffer_size: usize,
 }
 
 impl BufferPool {
     /// Instantiates a buffer pool backed by memory passed to it. We chunk
     /// out memory provided by backing into buffers of size `buffer_size`.
-    /// 
+    ///
     /// Note that we assume that backing is large enough for all buffers.
     /// Caller is responsible for ensuring backing is at least
     /// [`BufferPool::calculate_mapping_size`] bytes.
-    /// 
+    ///
     /// [`calculate_mapping_size`]: Self::calculate_mapping_size
-    pub fn new(
-        buffer_size: usize,
-        buffer_pool_size: usize,
-        mut backing: *mut u8,
-    ) -> Self {
+    pub fn new(buffer_size: usize, buffer_pool_size: usize, mut backing: *mut u8) -> Self {
         let pool = (0..buffer_pool_size)
             .map(|_| {
                 let header = backing as *mut BufferHeader;
+                unsafe {
+                    (*header) = BufferHeader {
+                        next: AtomicU32::new(0),
+                        length: AtomicU16::new(0),
+                        free: AtomicBool::new(true),
+                        more: AtomicBool::new(false),
+                    };
+                }
+                
                 let data = unsafe { backing.add(size_of::<BufferHeader>()) };
                 let buffer = Buffer { header, data };
-                backing = unsafe { backing.add(buffer_size) };
+                backing = unsafe { data.add(buffer_size) };
                 buffer
             })
             .collect();
@@ -67,31 +82,173 @@ impl BufferPool {
         Self {
             next: 0,
             pool,
+            buffer_size,
         }
     }
 
     /// Requests a chain of buffers to accomodate a payload of the given length
-    /// 
+    /// Assumes length is non-zero
+    ///
     /// Returns None if there is no chain of buffers that can accomodate the
-    /// payload
-    pub fn alloc_chain(&mut self, length: usize) -> Option<Buffer> {
+    /// payload, otherwise returns tuple of (Buffer, index)
+    pub fn alloc_chain(&mut self, length: usize) -> Option<(Buffer, usize)> {
+        let buffers_needed = (length + self.buffer_size - 1) / self.buffer_size;
+        if buffers_needed == 1 {
+            return self.alloc_single();
+        }
+
+        // allocate first buffer and keep track of it as our head
+        let (head, head_idx) = self.alloc_single()?;
+        let mut current = head.clone();
+
+        // create and link remaining buffers
+        for _ in 1..buffers_needed {
+            if let Some((next_buffer, next_idx)) = self.alloc_single() {
+                unsafe {
+                    (*current.header).more.store(true, Ordering::Release);
+                    (*current.header).next.store(next_idx as u32, Ordering::Release);
+                }
+                current = next_buffer;
+            } else {
+                // failed to allocate enough buffers, release what we had
+                println!("failed to allocate, not enough available buffers.");
+                self.release_chain(&head);
+                return None;
+            }
+        }
+
+        // tidy the last buffer
+        unsafe {
+            (*current.header).more.store(false, Ordering::Release);
+            (*current.header).next.store(0, Ordering::Release);
+        }
+
+        Some((head, head_idx))
+    }
+
+    /// Allocate a single buffer
+    /// Returns tuple of (Buffer, index) if successful
+    fn alloc_single(&mut self) -> Option<(Buffer, usize)> {
+        let buffer_pool_size = self.pool.len();
+        let start = self.next;
+
+        // try to find a free buffer starting from next
+        for i in 0..buffer_pool_size {
+            let idx = (start + i) % buffer_pool_size;
+            unsafe {
+                if (*self.pool[idx].header).free.compare_exchange(
+                    true,
+                    false,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                ).is_ok() {
+                    (*self.pool[idx].header).length.store(0, Ordering::Release);
+                    (*self.pool[idx].header).more.store(false, Ordering::Release);
+                    (*self.pool[idx].header).next.store(0, Ordering::Release);
+
+                    self.next = (idx + 1) % buffer_pool_size;
+                    return Some((self.pool[idx].clone(), idx));
+                }
+            }
+        }
+
         None
+    }
+
+    /// Writes data across a chain of buffers
+    /// Returns Some(bytes_written) if all data was written successfully,
+    /// or None if the provided chain didn't have enough capacity
+    pub unsafe fn write_chain(&self, head: &Buffer, data: &[u8]) -> Option<usize> {
+        let mut current: &Buffer = head;
+        let mut bytes_remaining = data.len();
+        let mut bytes_written = 0;
+        
+        while bytes_remaining > 0 {
+            // if data is already present in this buffer
+            // for some reason, unsuccessful write
+            assert!((*current.header).length.load(Ordering::Acquire) == 0, "Buffer should be empty");
+
+            // calculate how much we can write to this buffer
+            let write_size = bytes_remaining.min(self.buffer_size);
+            // copy data into the current buffer
+            std::ptr::copy_nonoverlapping(
+                data.as_ptr().add(bytes_written),
+                current.data,
+                write_size
+            );
+            // update the length in the buffer header
+            (*current.header).length.store(write_size as u16, Ordering::Release);
+            
+            bytes_written += write_size;
+            bytes_remaining -= write_size;
+            
+            // move to next buffer if there's more data and more buffers
+            if bytes_remaining > 0 {
+                if !(*current.header).more.load(Ordering::Acquire) {
+                    println!("no more buffers available");
+                    // chain ended before we could write all data
+                    return None;
+                }
+                current = &self.pool[(*current.header).next.load(Ordering::Acquire) as usize];
+            }
+        }
+        
+        Some(bytes_written)
+    }
+
+    /// Reads data from a chain of buffers into the provided slice
+    /// Returns number of bytes read
+    pub unsafe fn read_chain(&self, head: &Buffer, data: &mut [u8]) -> usize {
+        let mut current = head;
+        let mut bytes_read = 0;
+        
+        loop {
+            let buffer_length = (*current.header).length.load(Ordering::Acquire) as usize;
+            
+            // copy data from the current buffer
+            if buffer_length > 0 {
+                let read_size = buffer_length.min(data.len() - bytes_read);
+                std::ptr::copy_nonoverlapping(
+                    current.data,
+                    data.as_mut_ptr().add(bytes_read),
+                    read_size
+                );
+                bytes_read += read_size;
+            }
+            
+            // move to next buffer if there is one
+            if !(*current.header).more.load(Ordering::Acquire) || bytes_read >= data.len() {
+                break;
+            }
+            current = &self.pool[(*current.header).next.load(Ordering::Acquire) as usize];
+        }
+        
+        bytes_read
+    }
+
+    /// Retrieves a buffer at a given index from the pool.
+    pub fn get_buffer(&self, index: u32) -> Buffer {
+        self.pool[index as usize].clone()
     }
 
     /// Releases a chain of buffers starting at the given buffer. Only the
     /// "root" buffer may be given.
-    /// 
+    ///
     /// Note that this does not follow Rust's typical semantics of Drop
     /// releasing resources, because we need to make our own decision about
     /// when to communicate that this underlying memory is free.
-    pub fn release_chain(&mut self, head: &Buffer) {
+    pub fn release_chain(&self, head: &Buffer) {
         unsafe {
             let mut current = head;
-            while !(*current.header).more {
-                (*current.header).free = true;
-                let next = (*current.header).next;
+            while (*current.header).more.load(Ordering::Acquire) {
+                let next = (*current.header).next.load(Ordering::Acquire);
+                (*current.header).length.store(0, Ordering::Release);
+                (*current.header).free.store(true, Ordering::Release);
                 current = &self.pool[next as usize];
             }
+
+            // release the tail
+            (*current.header).free.store(true, Ordering::Release);
         }
     }
 
@@ -119,11 +276,8 @@ impl BufferPool {
         let pgsz = page_size - 1;
 
         // size of every buffer will be buffer_size + size of header, and
-        // rounded up to the closest size that is a mulitple of CACHE_LINE_SIZE
-        let bufsz = Self::calculate_buffer_size(
-            buffer_size,
-            cache_line_size
-        );
+        // rounded up to the closest size that is a multiple of CACHE_LINE_SIZE
+        let bufsz = Self::calculate_buffer_size(buffer_size, cache_line_size);
 
         // the pool size will be the bufsz * number of items in the pool, and
         // rounded up to the closest size that is a multiple of PAGE_SIZE
@@ -134,10 +288,7 @@ impl BufferPool {
     }
 
     /// Rounds up the buffer size to the closest multiple of cache line size
-    fn calculate_buffer_size(
-        buffer_size: usize,
-        cache_line_size: usize
-    ) -> usize {
+    fn calculate_buffer_size(buffer_size: usize, cache_line_size: usize) -> usize {
         // assert that cache_line_size is a power of 2
         assert!(cache_line_size.is_power_of_two());
 
@@ -148,5 +299,153 @@ impl BufferPool {
         let mut bufsz = buffer_size + size_of::<BufferHeader>();
         bufsz = (bufsz + cachesz) & !cachesz;
         bufsz
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_test_pool(buffer_size: usize, pool_size: usize) -> (BufferPool, Vec<u8>) {
+        let cache_line_size = 64;
+        let page_size = 4096;
+        let mapping_size = BufferPool::calculate_mapping_size(
+            buffer_size,
+            pool_size,
+            page_size,
+            cache_line_size,
+        );
+        
+        let mut backing = vec![0u8; mapping_size];
+        let pool = BufferPool::new(
+            buffer_size,
+            pool_size,
+            backing.as_mut_ptr(),
+        );
+        (pool, backing)
+    }
+
+    #[test]
+    fn test_alloc_single_buffer() {
+        let buffer_size = 1024;
+        let pool_size = 4;
+        let (mut pool, _backing) = create_test_pool(buffer_size, pool_size);
+
+        // allocate a buffer for data that fits in a single buffer
+        let (buffer, _head_idx) = pool.alloc_chain(500).expect("Should allocate successfully");
+        
+        unsafe {
+            assert!(!(*buffer.header).free.load(Ordering::Acquire), "Buffer should not be marked as free");
+            assert!(!(*buffer.header).more.load(Ordering::Acquire), "Single buffer should not have more buffers");
+            assert_eq!((*buffer.header).next.load(Ordering::Acquire), 0, "Single buffer should have next set to 0");
+        }
+
+        pool.release_chain(&buffer);
+        unsafe {
+            assert!((*buffer.header).free.load(Ordering::Acquire), "Buffer should be marked as free after release");
+        }
+    }
+
+    #[test]
+    fn test_alloc_multiple_buffers() {
+        let buffer_size = 1024;
+        let pool_size = 4;
+        let (mut pool, _backing) = create_test_pool(buffer_size, pool_size);
+
+        // allocate a chain for data that spans multiple buffers
+        let (buffer, _head_idx) = pool.alloc_chain(1500).expect("Should allocate successfully");
+        
+        unsafe {
+            // check first buffer
+            assert!(!(*buffer.header).free.load(Ordering::Acquire), "First buffer should not be marked as free");
+            assert!((*buffer.header).more.load(Ordering::Acquire), "First buffer should have more buffers");
+            let next_idx = (*buffer.header).next.load(Ordering::Acquire) as usize;
+            
+            // check second buffer
+            let next_buffer = &pool.pool[next_idx];
+            assert!(!(*next_buffer.header).free.load(Ordering::Acquire), "Second buffer should not be marked as free");
+            assert!(!(*next_buffer.header).more.load(Ordering::Acquire), "Second buffer should not have more buffers");
+        }
+
+        pool.release_chain(&buffer);
+        unsafe {
+            assert!((*buffer.header).free.load(Ordering::Acquire), "First buffer should be marked as free after release");
+            let next_idx = (*buffer.header).next.load(Ordering::Acquire) as usize;
+            let next_buffer = &pool.pool[next_idx];
+            assert!((*next_buffer.header).free.load(Ordering::Acquire), "Second buffer should be marked as free after release");
+        }
+    }
+
+    #[test]
+    fn test_alloc_chain_out_of_buffers() {
+        let buffer_size = 1024;
+        let pool_size = 2;
+        let (mut pool, _backing) = create_test_pool(buffer_size, pool_size);
+
+        // first allocation should succeed
+        let _first = pool.alloc_chain(1500).expect("First allocation should succeed");
+        
+        // second allocation requiring two buffers should fail
+        let second = pool.alloc_chain(1500);
+        assert!(second.is_none(), "Should fail when out of buffers");
+    }
+
+    #[test]
+    fn test_alloc_chain_sequential() {
+        let buffer_size = 1024;
+        let pool_size = 4;
+        let (mut pool, _backing) = create_test_pool(buffer_size, pool_size);
+
+        // allocate and verify the chain
+        let (first, _head_idx) = pool.alloc_chain(500).expect("First allocation should succeed");
+        let (second, _head_idx) = pool.alloc_chain(500).expect("Second allocation should succeed");
+        
+        unsafe {
+            assert!(!(*first.header).free.load(Ordering::Acquire));
+            assert!(!(*second.header).free.load(Ordering::Acquire));
+        }
+    }
+
+    #[test]
+    fn test_write_and_read_single_buffer() {
+        let buffer_size = 1024;
+        let pool_size = 4;
+        let (mut pool, _backing) = create_test_pool(buffer_size, pool_size);
+        
+        let test_data = b"Hello, World!";
+        let (buffer,_head_idx) = pool.alloc_chain(test_data.len()).expect("Should allocate successfully");
+        
+        unsafe {
+            let written = pool.write_chain(&buffer, test_data);
+            assert_eq!(written.expect("Should successfully write bytes"), test_data.len());
+            
+            let mut output = vec![0u8; test_data.len()];
+            let read = pool.read_chain(&buffer, &mut output);
+            
+            assert_eq!(read, test_data.len());
+            assert_eq!(&output, test_data);
+        }
+    }
+
+    #[test]
+    fn test_write_and_read_multiple_buffers() {
+        let buffer_size = 64;
+        let pool_size = 4;
+        let (mut pool, _backing) = create_test_pool(buffer_size, pool_size);
+        
+        // create test data that's longer than a single buffer (>64 bytes)
+        let test_data = b"This is a much longer string that will definitely span multiple buffers because it needs to be longer than 64 bytes to ensure proper testing of the multi-buffer functionality in our implementation";
+        let (buffer, _head_idx) = pool.alloc_chain(test_data.len()).expect("Should allocate successfully");
+        
+        unsafe {
+            let written = pool.write_chain(&buffer, test_data);
+            assert_eq!(written.expect("Should successfully write bytes"), test_data.len());
+
+            let mut output = vec![0u8; test_data.len()];
+            let read = pool.read_chain(&buffer, &mut output);
+            
+            assert_eq!(read, test_data.len());
+            assert_eq!(&output, test_data);
+        }
     }
 }


### PR DESCRIPTION
- `BufferPool` impl to allow for allocating a chain of smaller buffers for a single byte msg from `Mapping`
- `Mapping` updates:
  - ring buffer with X `slots` that contain the index of a particular slot's buffer chain head
  - allocate space in backing for buffer pool
  - `Mapping` enqueue/dequeue fn signatures are now `&mut`, `ArcSwap` contains `Mutex<Mapping>`