### PR TITLE
enqueue/dequeue benches, optional topic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,10 @@ serde = { version = "1.0.213", features = ["derive"] }
 tokio = { version = "1.40.0", features = ["rt-multi-thread", "net", "macros"] }
 tokio-stream = { version = "0.1.16", features = ["net"] }
 tokio-util = { version = "0.7.12", features = ["io", "codec"] }
+
+[dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "pubsub"
+harness = false

--- a/benches/pubsub.rs
+++ b/benches/pubsub.rs
@@ -1,0 +1,187 @@
+use criterion::{
+    black_box, 
+    criterion_group, 
+    criterion_main, 
+    BenchmarkId, 
+    Criterion
+};
+use llmq::{Broker, PubSub};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+use serde::{Serialize, Deserialize};
+
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+struct BenchMessage {
+    payload: Vec<u8>,
+    sequence: u64,
+}
+
+fn setup_broker() -> (Arc<Broker>, Vec<thread::JoinHandle<()>>) {
+    let broker = Arc::new(Broker::new(
+        "/tmp/llmq.sock",
+        "/dev/shm"
+    ));
+    let mut broker_threads= Vec::new();
+
+    // spawn the control and data planes
+    broker_threads.push(thread::spawn({
+        let broker = Arc::clone(&broker);
+        move || broker.run_control_plane_blocking()
+    }));
+
+    broker_threads.push(thread::spawn({
+        let broker = Arc::clone(&broker);
+        move || broker.run_data_plane_blocking()
+    }));
+
+    thread::sleep(Duration::from_millis(100));
+    
+    (broker, broker_threads)
+}
+
+
+fn enqueue_throughput_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("pubsub_throughput");
+    let message_sizes = [64, 128, 256, 512];
+    
+    let (_broker, _handles) = setup_broker();
+
+    let mut publisher = PubSub::default();
+    let mut subscriber = PubSub::default();
+    
+    publisher.connect().expect("Failed to connect publisher");
+    subscriber.connect().expect("Failed to connect subscriber");
+    subscriber.add_subscription("bench-topic");
+    
+    let running = Arc::new(AtomicBool::new(true));
+    // we can start the dequeue thread outside of bench_with_input
+    // as it doesn't depend on the size param
+    let dequeue_thread = {
+        let running = Arc::clone(&running);
+        thread::spawn(move || {
+            while running.load(Ordering::Relaxed) {
+                let _ = subscriber.dequeue_type::<BenchMessage>();
+            }
+        })
+    };
+    
+    for size in message_sizes {
+        group.bench_with_input(
+            BenchmarkId::new("enqueue_throughput_benchmark", size),
+            &size,
+            |b, &size| {
+                let msg = BenchMessage {
+                    payload: vec![0u8; size],
+                    sequence: 0,
+                };
+
+                b.iter(|| {
+                    publisher.enqueue_type("bench-topic", &msg)
+                });
+            },
+        );
+    }
+
+    // spin down dequeue thread
+    running.store(false, Ordering::Relaxed);
+    dequeue_thread.join().unwrap();
+    
+    group.finish();
+}
+
+fn dequeue_throughput_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("pubsub_throughput");
+    let message_sizes = [64, 128, 256, 512];
+    
+    let (_broker, _handles) = setup_broker();
+
+    let mut publisher = PubSub::default();
+    let mut subscriber = PubSub::default();
+
+    publisher.connect().expect("Failed to connect publisher");
+    subscriber.connect().expect("Failed to connect subscriber");
+    subscriber.add_subscription("bench-topic");
+    
+    let publisher = Arc::new(Mutex::new(publisher));
+    
+    for size in message_sizes {
+        group.bench_with_input(
+            BenchmarkId::new("dequeue_throughput_benchmark", size),
+            &size,
+            |b, &size| {
+                let msg = BenchMessage {
+                    payload: vec![0u8; size],
+                    sequence: 0,
+                };
+
+                let publisher = Arc::clone(&publisher);
+                // publisher thread w/corresponding size to firehose messages
+                let publish_thread = thread::spawn(move || {
+                    loop {
+                        publisher.lock().unwrap().enqueue_type("bench-topic", &msg);
+                    }
+                });
+
+                b.iter(|| {
+                    let _ = black_box(subscriber.dequeue_type::<BenchMessage>());
+                });
+
+                drop(publish_thread);
+            },
+        );
+    }
+    group.finish();
+}
+
+fn dequeue_no_topic_throughput_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("pubsub_throughput");
+    let message_sizes = [64, 128, 256, 512];
+    
+    let (_broker, _handles) = setup_broker();
+
+    let mut publisher = PubSub::default();
+    let mut subscriber = PubSub::default();
+    publisher.connect().expect("Failed to connect publisher");
+    subscriber.connect().expect("Failed to connect subscriber");
+    subscriber.add_subscription("bench-topic");
+    
+    let publisher = Arc::new(Mutex::new(publisher));
+    
+    for size in message_sizes {
+        group.bench_with_input(
+            BenchmarkId::new("dequeue_no_topic_throughput_benchmark", size),
+            &size,
+            |b, &size| {
+                let msg = BenchMessage {
+                    payload: vec![0u8; size],
+                    sequence: 0,
+                };
+                let publisher = Arc::clone(&publisher);
+                // publisher thread w/corresponding size to firehose messages
+                let publish_thread = thread::spawn(move || {
+                    loop {
+                        publisher.lock().unwrap().enqueue_type("bench-topic", &msg);
+                    }
+                });
+
+                b.iter(|| {
+                    black_box(subscriber.dequeue_bytes_no_topic());
+                });
+
+                drop(publish_thread);
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    enqueue_throughput_benchmark,
+    dequeue_throughput_benchmark,
+    dequeue_no_topic_throughput_benchmark,
+);
+criterion_main!(benches);


### PR DESCRIPTION
- integrate [criterion](https://github.com/bheisler/criterion.rs) benches for performance review of enqueue/dequeue functionalities
- support dequeue'ing w/optional topic retrieval to avoid str allocation
- use references where possible

```
     Running benches/pubsub.rs (target/release/deps/pubsub-94232d48e4de31fd)
Gnuplot not found, using plotters backend
pubsub_throughput/enqueue_throughput_benchmark/64
                        time:   [110.72 ns 110.82 ns 110.91 ns]
                        change: [+42.889% +43.122% +43.322%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) low mild
  1 (1.00%) high severe
pubsub_throughput/enqueue_throughput_benchmark/128
                        time:   [155.83 ns 155.97 ns 156.11 ns]
                        change: [+2.0283% +2.1409% +2.2563%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe
pubsub_throughput/enqueue_throughput_benchmark/256
                        time:   [318.05 ns 318.16 ns 318.27 ns]
                        change: [+3.6897% +3.7467% +3.8035%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) low mild
  2 (2.00%) high mild
pubsub_throughput/enqueue_throughput_benchmark/512
                        time:   [782.42 ns 782.84 ns 783.29 ns]
                        change: [+31.047% +31.217% +31.383%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) low mild

pubsub_throughput/dequeue_throughput_benchmark/64
                        time:   [33.676 ns 33.830 ns 34.001 ns]
                        change: [+202.84% +209.83% +215.06%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
pubsub_throughput/dequeue_throughput_benchmark/128
                        time:   [10.509 ns 10.599 ns 10.700 ns]
                        change: [-69.028% -68.545% -68.034%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) low mild
pubsub_throughput/dequeue_throughput_benchmark/256
                        time:   [19.268 ns 21.567 ns 24.081 ns]
                        change: [-16.479% -10.869% -5.7017%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 22 outliers among 100 measurements (22.00%)
  21 (21.00%) low severe
  1 (1.00%) low mild
pubsub_throughput/dequeue_throughput_benchmark/512
                        time:   [31.388 ns 31.619 ns 31.840 ns]
                        change: [+50.412% +64.338% +80.573%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

pubsub_throughput/dequeue_no_topic_throughput_benchmark/64
                        time:   [15.936 ns 16.132 ns 16.330 ns]
                        change: [-19.863% -17.735% -15.614%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild
pubsub_throughput/dequeue_no_topic_throughput_benchmark/128
                        time:   [14.995 ns 15.224 ns 15.463 ns]
                        change: [-13.355% -11.344% -9.1898%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
pubsub_throughput/dequeue_no_topic_throughput_benchmark/256
                        time:   [13.416 ns 13.610 ns 13.820 ns]
                        change: [+4.0843% +6.8760% +9.7270%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
pubsub_throughput/dequeue_no_topic_throughput_benchmark/512
                        time:   [12.209 ns 12.309 ns 12.407 ns]
                        change: [+49.367% +51.444% +53.550%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  6 (6.00%) high mild
  1 (1.00%) high severe
```