### PR TITLE
bulk enqueue/dequeue + benches

### DIFF
--- a/benches/pubsub.rs
+++ b/benches/pubsub.rs
@@ -43,7 +43,7 @@ fn setup_broker() -> (Arc<Broker>, Vec<thread::JoinHandle<()>>) {
 }
 
 
-fn enqueue_throughput_benchmark(c: &mut Criterion) {
+fn enqueue_type_throughput_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("pubsub_throughput");
     let message_sizes = [64, 128, 256, 512];
     
@@ -70,7 +70,7 @@ fn enqueue_throughput_benchmark(c: &mut Criterion) {
     
     for size in message_sizes {
         group.bench_with_input(
-            BenchmarkId::new("enqueue_throughput_benchmark", size),
+            BenchmarkId::new("enqueue_type_throughput_benchmark", size),
             &size,
             |b, &size| {
                 let msg = BenchMessage {
@@ -92,7 +92,149 @@ fn enqueue_throughput_benchmark(c: &mut Criterion) {
     group.finish();
 }
 
-fn dequeue_throughput_benchmark(c: &mut Criterion) {
+fn enqueue_bulk_type_throughput_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("pubsub_throughput");
+    let message_sizes = [64, 128, 256, 512];
+    let batch_sizes = [10, 100, 1000];
+    
+    let (_broker, _handles) = setup_broker();
+    let mut publisher = PubSub::default();
+    let mut subscriber = PubSub::default();
+    
+    publisher.connect().expect("Failed to connect publisher");
+    subscriber.connect().expect("Failed to connect subscriber");
+    subscriber.add_subscription("bench-topic");
+    
+    let running = Arc::new(AtomicBool::new(true));
+    let dequeue_thread = {
+        let running = Arc::clone(&running);
+        thread::spawn(move || {
+            while running.load(Ordering::Relaxed) {
+                let _ = subscriber.dequeue_type::<BenchMessage>();
+            }
+        })
+    };
+    
+    for size in message_sizes {
+        for batch_size in batch_sizes {
+            group.bench_with_input(
+                BenchmarkId::new("enqueue_bulk_type_throughput_benchmark", format!("{}bytes_{}batch", size, batch_size)),
+                &(size, batch_size),
+                |b, &(size, batch_size)| {
+                    let messages = vec![BenchMessage {
+                        payload: vec![0u8; size],
+                        sequence: 0,
+                    }; batch_size];
+                    
+                    let msgs: Vec<_> = messages.iter()
+                        .map(|msg| ("bench-topic", msg))
+                        .collect();
+                    
+                    b.iter(|| {
+                        publisher.enqueue_bulk_type(&msgs)
+                    });
+                },
+            );
+        }
+    }
+    
+    running.store(false, Ordering::Relaxed);
+    dequeue_thread.join().unwrap();
+    
+    group.finish();
+}
+
+fn enqueue_bytes_throughput_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("pubsub_throughput");
+    let message_sizes = [64, 128, 256, 512];
+    
+    let (_broker, _handles) = setup_broker();
+    let mut publisher = PubSub::default();
+    let mut subscriber = PubSub::default();
+    
+    publisher.connect().expect("Failed to connect publisher");
+    subscriber.connect().expect("Failed to connect subscriber");
+    subscriber.add_subscription("bench-topic");
+    
+    let running = Arc::new(AtomicBool::new(true));
+    let dequeue_thread = {
+        let running = Arc::clone(&running);
+        thread::spawn(move || {
+            while running.load(Ordering::Relaxed) {
+                let _ = subscriber.dequeue_bytes();
+            }
+        })
+    };
+    
+    for size in message_sizes {
+        group.bench_with_input(
+            BenchmarkId::new("enqueue_bytes_throughput_benchmark", size),
+            &size,
+            |b, &size| {
+                let payload = vec![0u8; size];
+                b.iter(|| {
+                    publisher.enqueue_bytes("bench-topic", &payload)
+                });
+            },
+        );
+    }
+    
+    running.store(false, Ordering::Relaxed);
+    dequeue_thread.join().unwrap();
+    
+    group.finish();
+}
+
+fn enqueue_bulk_bytes_throughput_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("pubsub_throughput");
+    let message_sizes = [64, 128, 256, 512];
+    let batch_sizes = [10, 100, 1000];
+    
+    let (_broker, _handles) = setup_broker();
+    let mut publisher = PubSub::default();
+    let mut subscriber = PubSub::default();
+    
+    publisher.connect().expect("Failed to connect publisher");
+    subscriber.connect().expect("Failed to connect subscriber");
+    subscriber.add_subscription("bench-topic");
+    
+    let running = Arc::new(AtomicBool::new(true));
+    let dequeue_thread = {
+        let running = Arc::clone(&running);
+        thread::spawn(move || {
+            while running.load(Ordering::Relaxed) {
+                let _ = subscriber.dequeue_bytes();
+            }
+        })
+    };
+    
+    for size in message_sizes {
+        for batch_size in batch_sizes {
+            group.bench_with_input(
+                BenchmarkId::new("enqueue_bulk_bytes_throughput_benchmark", format!("{}bytes_{}batch", size, batch_size)),
+                &(size, batch_size),
+                |b, &(size, batch_size)| {
+                    let msgs: Vec<_> = (0..batch_size)
+                        .map(|_| ("bench-topic", vec![0u8; size]))
+                        .collect();
+                    
+                    b.iter(|| {
+                        publisher.enqueue_bulk_bytes(&msgs)
+                    });
+                },
+            );
+        }
+    }
+    
+    running.store(false, Ordering::Relaxed);
+    dequeue_thread.join().unwrap();
+    
+    group.finish();
+}
+
+
+
+fn dequeue_type_throughput_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("pubsub_throughput");
     let message_sizes = [64, 128, 256, 512];
     
@@ -106,10 +248,11 @@ fn dequeue_throughput_benchmark(c: &mut Criterion) {
     subscriber.add_subscription("bench-topic");
     
     let publisher = Arc::new(Mutex::new(publisher));
-    
+    let running = Arc::new(AtomicBool::new(true));
+
     for size in message_sizes {
         group.bench_with_input(
-            BenchmarkId::new("dequeue_throughput_benchmark", size),
+            BenchmarkId::new("dequeue_type_throughput_benchmark", size),
             &size,
             |b, &size| {
                 let msg = BenchMessage {
@@ -118,10 +261,15 @@ fn dequeue_throughput_benchmark(c: &mut Criterion) {
                 };
 
                 let publisher = Arc::clone(&publisher);
+                running.store(true, Ordering::Relaxed);
+                let thread_running = Arc::clone(&running);
                 // publisher thread w/corresponding size to firehose messages
                 let publish_thread = thread::spawn(move || {
-                    loop {
-                        publisher.lock().unwrap().enqueue_type("bench-topic", &msg);
+                    // serialize one time and call enqueue_bytes directly 
+                    // so enqueue is speedy
+                    let bytes = bincode::serialize(&msg).unwrap();
+                    while thread_running.load(Ordering::Relaxed) {
+                        publisher.lock().unwrap().enqueue_bytes("bench-topic", &bytes);
                     }
                 });
 
@@ -129,10 +277,168 @@ fn dequeue_throughput_benchmark(c: &mut Criterion) {
                     let _ = black_box(subscriber.dequeue_type::<BenchMessage>());
                 });
 
-                drop(publish_thread);
+                running.store(false, Ordering::Relaxed);
+                publish_thread.join().unwrap();
             },
         );
     }
+
+    group.finish();
+}
+
+fn dequeue_bulk_type_throughput_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("pubsub_throughput");
+    let message_sizes = [64, 128, 256, 512];
+    let batch_sizes = [10, 100, 1000];
+    
+    let (_broker, _handles) = setup_broker();
+
+    let mut publisher = PubSub::default();
+    let mut subscriber = PubSub::default();
+    
+    publisher.connect().expect("Failed to connect publisher");
+    subscriber.connect().expect("Failed to connect subscriber");
+    subscriber.add_subscription("bench-topic");
+    
+    let publisher = Arc::new(Mutex::new(publisher));
+    let running = Arc::new(AtomicBool::new(true));
+    
+    for size in message_sizes {
+        for batch_size in batch_sizes {
+            group.bench_with_input(
+                BenchmarkId::new("dequeue_bulk_type_throughput_benchmark", format!("{}bytes_{}batch", size, batch_size)),
+                &(size, batch_size),
+                |b, &(size, batch_size)| {
+                    let msg = BenchMessage {
+                        payload: vec![0u8; size],
+                        sequence: 0,
+                    };
+
+                    let publisher = Arc::clone(&publisher);
+                    running.store(true, Ordering::Relaxed);
+                    let thread_running = Arc::clone(&running);
+                    // publisher thread w/corresponding size to firehose messages
+                    let publish_thread = thread::spawn(move || {
+                        // serialize one time and call enqueue_bytes directly 
+                        // so enqueue is speedy
+                        let bytes = bincode::serialize(&msg).unwrap();
+                        while thread_running.load(Ordering::Relaxed) {
+                            let msgs: Vec<_> = (0..batch_size)
+                                .map(|_| ("bench-topic", &bytes[..]))
+                                .collect();
+                            publisher.lock().unwrap().enqueue_bulk_bytes(&msgs);
+                        }
+                    });
+
+                    b.iter(|| {
+                        black_box(subscriber.dequeue_bulk_type::<BenchMessage>(batch_size));
+                    });
+
+                    running.store(false, Ordering::Relaxed);
+                    publish_thread.join().unwrap();
+                },
+            );
+        }
+    }
+    
+    group.finish();
+}
+
+fn dequeue_bytes_throughput_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("pubsub_throughput");
+    let message_sizes = [64, 128, 256, 512];
+    
+    let (_broker, _handles) = setup_broker();
+
+    let mut publisher = PubSub::default();
+    let mut subscriber = PubSub::default();
+    
+    publisher.connect().expect("Failed to connect publisher");
+    subscriber.connect().expect("Failed to connect subscriber");
+    subscriber.add_subscription("bench-topic");
+    
+    let publisher = Arc::new(Mutex::new(publisher));
+    let running = Arc::new(AtomicBool::new(true));
+
+    for size in message_sizes {
+        group.bench_with_input(
+            BenchmarkId::new("dequeue_bytes_throughput_benchmark", size),
+            &size,
+            |b, &size| {
+                let payload = vec![0u8; size];
+                
+                let publisher = Arc::clone(&publisher);
+                running.store(true, Ordering::Relaxed);
+                let thread_running = Arc::clone(&running);
+                // publisher thread w/corresponding size to firehose messages
+                let publish_thread = thread::spawn(move || {
+                    while thread_running.load(Ordering::Relaxed) {
+                        publisher.lock().unwrap().enqueue_bytes("bench-topic", &payload);
+                    }
+                });
+
+                b.iter(|| {
+                    let _ = black_box(subscriber.dequeue_bytes());
+                });
+
+                running.store(false, Ordering::Relaxed);
+                publish_thread.join().unwrap();
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn dequeue_bulk_bytes_throughput_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("pubsub_throughput");
+    let message_sizes = [64, 128, 256, 512];
+    let batch_sizes = [10, 100, 1000];
+    
+    let (_broker, _handles) = setup_broker();
+
+    let mut publisher = PubSub::default();
+    let mut subscriber = PubSub::default();
+    
+    publisher.connect().expect("Failed to connect publisher");
+    subscriber.connect().expect("Failed to connect subscriber");
+    subscriber.add_subscription("bench-topic");
+    
+    let publisher = Arc::new(Mutex::new(publisher));
+    let running = Arc::new(AtomicBool::new(true));
+    
+    for size in message_sizes {
+        for batch_size in batch_sizes {
+            group.bench_with_input(
+                BenchmarkId::new("dequeue_bulk_bytes_throughput_benchmark", format!("{}bytes_{}batch", size, batch_size)),
+                &(size, batch_size),
+                |b, &(size, batch_size)| {
+                    let payload = vec![0u8; size];
+
+                    let publisher = Arc::clone(&publisher);
+                    running.store(true, Ordering::Relaxed);
+                    let thread_running = Arc::clone(&running);
+                    // publisher thread w/corresponding size to firehose messages
+                    let publish_thread = thread::spawn(move || {
+                        while thread_running.load(Ordering::Relaxed) {
+                            let msgs: Vec<_> = (0..batch_size)
+                                .map(|_| ("bench-topic", &payload[..]))
+                                .collect();
+                            publisher.lock().unwrap().enqueue_bulk_bytes(&msgs);
+                        }
+                    });
+
+                    b.iter(|| {
+                        black_box(subscriber.dequeue_bulk_bytes(batch_size));
+                    });
+
+                    running.store(false, Ordering::Relaxed);
+                    publish_thread.join().unwrap();
+                },
+            );
+        }
+    }
+    
     group.finish();
 }
 
@@ -179,9 +485,38 @@ fn dequeue_no_topic_throughput_benchmark(c: &mut Criterion) {
 }
 
 criterion_group!(
-    benches,
-    enqueue_throughput_benchmark,
-    dequeue_throughput_benchmark,
+    typed_single_benchmarks,
+    enqueue_type_throughput_benchmark,
+    dequeue_type_throughput_benchmark,
+);
+
+criterion_group!(
+    typed_bulk_benchmarks,
+    enqueue_bulk_type_throughput_benchmark,
+    dequeue_bulk_type_throughput_benchmark,
+);
+
+criterion_group!(
+    bytes_single_benchmarks,
+    enqueue_bytes_throughput_benchmark,
+    dequeue_bytes_throughput_benchmark,
+);
+
+criterion_group!(
+    bytes_bulk_benchmarks,
+    enqueue_bulk_bytes_throughput_benchmark,
+    dequeue_bulk_bytes_throughput_benchmark,
+);
+
+criterion_group!(
+    isolated_benchmarks,
     dequeue_no_topic_throughput_benchmark,
 );
-criterion_main!(benches);
+
+criterion_main!(
+    typed_single_benchmarks,
+    typed_bulk_benchmarks,
+    bytes_single_benchmarks,
+    bytes_bulk_benchmarks,
+    isolated_benchmarks,
+);

--- a/src/broker/forwarding_table.rs
+++ b/src/broker/forwarding_table.rs
@@ -41,26 +41,20 @@ impl ForwardingTable {
 
     /// Receives messages from publishers and forwards them to subscribers
     pub fn poll(&self) {
-        let mut buf = vec![(Some(String::new()), Vec::new()); 16];
-        let mut refs: Vec<(Option<&mut String>, &mut Vec<u8>)> = buf.iter_mut()
-            .map(|(t, p)| (t.as_mut(), p))
-            .collect();
-
-
         // iterate over every client that is capable of publishing to the
         // broker...
         for p in self.publishers.iter() {
             // get the next message from the client and break it down into
             // the topic and the body
+            let mut buf = vec![(String::new(), Vec::new()); 16];
             let rx_count = if let Some(rx) = p.rx_mapping.load().as_ref() {
-                unsafe { &mut *rx.get().get() }.dequeue_bulk_bytes(&mut refs, true)
+                unsafe { &mut *rx.get().get() }.dequeue_bulk_bytes(&mut buf, true)
             } else {
                 0
             };
 
             for idx in 0..rx_count {
-                let (topic_opt, body) = &refs[idx];
-                let Some(topic) = topic_opt else { continue };
+                let (topic, body) = &buf[idx];
                 
                 // walk the list of clients that are subscribed to the topic
                 // prefix and forward the message to them


### PR DESCRIPTION
- support for bulk enqueue/dequeue operations, additional benches
- add benches for byte-specific variants to isolate out serialization/deserialization costs

[bench results](https://gist.githubusercontent.com/davidiola/69672de83d6370cb34e70d61092e61c9/raw/2d5dcb5b72b690ba0ff7cff9a4fcdff22ed1a3c4/bench_results)