### PR TITLE
rkyv serialize/access

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ log = "0.4.22"
 md-5 = "0.10.6"
 memmap = "0.7.0"
 rand = "0.8.5"
+# default features of rkyv, explicitly enabled per documentation recommendation
+# https://docs.rs/rkyv/latest/rkyv/ 
+rkyv = { version = "0.8.8", features = ["std", "alloc", "bytecheck", "little_endian", "aligned", "pointer_width_32"]}
 serde = { version = "1.0.213", features = ["derive"] }
 tokio = { version = "1.40.0", features = ["rt-multi-thread", "net", "macros"] }
 tokio-stream = { version = "0.1.16", features = ["net"] }
@@ -29,4 +32,8 @@ criterion = { version = "0.5", features = ["html_reports"] }
 
 [[bench]]
 name = "pubsub"
+harness = false
+
+[[bench]]
+name = "rkyv"
 harness = false

--- a/benches/rkyv.rs
+++ b/benches/rkyv.rs
@@ -1,0 +1,101 @@
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use rkyv::{Archive, Deserialize, Serialize, rancor::Error};
+use serde::{Deserialize as SerdeDeserialize, Serialize as SerdeSerialize};
+
+#[derive(Archive, Deserialize, Serialize, SerdeDeserialize, SerdeSerialize, Clone)]
+#[rkyv(
+    compare(PartialEq),
+    derive(Debug),
+)]
+struct BenchMessage {
+    payload: Vec<u8>,
+    sequence: u64,
+}
+
+fn serialization_throughput_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("serialization_throughput");
+    let message_sizes = [64, 128, 256, 512];
+    
+    for size in message_sizes {
+        let msg = BenchMessage {
+            payload: vec![0u8; size],
+            sequence: 0,
+        };
+        
+        group.bench_with_input(
+            BenchmarkId::new("bincode_serialize", size),
+            &size,
+            |b, _size| {
+                b.iter(|| {
+                    black_box(bincode::serialize(&msg).unwrap())
+                });
+            },
+        );
+        
+        group.bench_with_input(
+            BenchmarkId::new("rkyv_serialize", size),
+            &size,
+            |b, _size| {
+                b.iter(|| {
+                    black_box(rkyv::to_bytes::<Error>(&msg).unwrap())
+                });
+            },
+        );
+    }
+    
+    group.finish();
+}
+
+fn deserialization_throughput_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("deserialization_throughput");
+    let message_sizes = [64, 128, 256, 512];
+    
+    for size in message_sizes {
+        let msg = BenchMessage {
+            payload: vec![0u8; size],
+            sequence: 0,
+        };
+        
+        let bincode_bytes = bincode::serialize(&msg).unwrap();
+        let rkyv_bytes = rkyv::to_bytes::<Error>(&msg).unwrap();
+        
+        group.bench_with_input(
+            BenchmarkId::new("bincode_deserialize", size),
+            &size,
+            |b, _size| {
+                b.iter(|| {
+                    black_box(bincode::deserialize::<BenchMessage>(&bincode_bytes).unwrap())
+                });
+            },
+        );
+        
+        group.bench_with_input(
+            BenchmarkId::new("rkyv_access", size),
+            &size,
+            |b, _size| {
+                b.iter(|| {
+                    black_box(rkyv::access::<ArchivedBenchMessage, Error>(&rkyv_bytes).unwrap())
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("rkyv_deserialize", size),
+            &size,
+            |b, _size| {
+                b.iter(|| {
+                    black_box(rkyv::from_bytes::<BenchMessage, Error>(&rkyv_bytes).unwrap())
+                });
+            },
+        );
+    }
+    
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    serialization_throughput_benchmark,
+    deserialization_throughput_benchmark
+);
+criterion_main!(benches);

--- a/src/broker/radix_tree.rs
+++ b/src/broker/radix_tree.rs
@@ -193,8 +193,8 @@ mod tests {
         tree.insert("abcdefghijklmnop", 1);
         tree.insert("abcdefghijklmnoz", 2);  
 
-        assert_eq!(tree.find("p"), vec![]);
-        assert_eq!(tree.find("z"), vec![]);
+        assert_eq!(tree.find("p").is_empty(), true);
+        assert_eq!(tree.find("z").is_empty(), true);
 
         tree.insert("abcdefghijk", 3);
         tree.insert("abcdefgh", 4);


### PR DESCRIPTION
- rkyv provides clear performance benefits over bincode, add bench comparison
- dequeue methods now make use of rkyv's [zero-copy access](https://docs.rs/rkyv/latest/rkyv/api/high/fn.access.html), and client can [deserialize to owned](https://docs.rs/rkyv/latest/rkyv/api/high/fn.deserialize.html) only when necessary

[rkyv bench results](https://gist.githubusercontent.com/davidiola/c89321d05ffc7a477d284bcdc8be960b/raw/f7416c0542212faaebc7ae68f880cdb60cb688a5/gistfile1.txt)